### PR TITLE
Allow padding in variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ mastodon-comments {
   --block-background-color: #f7f8f8;
 
   --comment-indent: 40px;
+  --comment-padding: 20px;
 }
 ```
 

--- a/mastodon-comments.js
+++ b/mastodon-comments.js
@@ -9,6 +9,7 @@ const styles = `
   --block-background-color: #f7f8f8;
 
   --comment-indent: 40px;
+  --comment-padding: 20px;
 }
 
 #mastodon-stats {
@@ -24,7 +25,7 @@ const styles = `
   background-color: var(--block-background-color);
   border-radius: var(--block-border-radius);
   border: var(--block-border-width) var(--block-border-color) solid;
-  padding: 20px;
+  padding: var(--comment-padding);
   margin-bottom: 1.5rem;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Hi, thanks for this project. It's the easiest way I've found to add Mastodon comments to Hugo.

Would you mind allowing to change the `padding` on the CSS variables?

I would like to have my implementation as similar as possible to upstream.